### PR TITLE
Fix car status update endpoint

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -2,7 +2,7 @@ from .base import UserRole, Transmission, Condition, DealStatus
 from .user import UserBase, UserCreate, UserInDB, User
 from .buyer import BuyerBase, BuyerCreate, BuyerInDB, Buyer
 from .seller import SellerBase, SellerCreate, SellerInDB, Seller
-from .car import CarBase, CarCreate, CarInDB, Car
+from .car import CarBase, CarCreate, CarInDB, Car, CarStatusUpdate
 from .store import StoreBase, StoreCreate, StoreInDB, Store
 from .favorite import FavoriteBase, FavoriteCreate, FavoriteInDB, Favorite
 from .deal import DealBase, DealCreate, DealInDB, Deal
@@ -12,7 +12,7 @@ __all__ = [
     "UserBase", "UserCreate", "UserInDB", "User",
     "BuyerBase", "BuyerCreate", "BuyerInDB", "Buyer",
     "SellerBase", "SellerCreate", "SellerInDB", "Seller",
-    "CarBase", "CarCreate", "CarInDB", "Car",
+    "CarBase", "CarCreate", "CarInDB", "Car", "CarStatusUpdate",
     "StoreBase", "StoreCreate", "StoreInDB", "Store",
     "FavoriteBase", "FavoriteCreate", "FavoriteInDB", "Favorite",
     "DealBase", "DealCreate", "DealInDB", "Deal"

--- a/backend/models/car.py
+++ b/backend/models/car.py
@@ -39,3 +39,8 @@ class Car(CarBase):
 
     class Config:
         from_attributes = True
+
+
+class CarStatusUpdate(BaseModel):
+    """Модель для обновления статуса автомобиля"""
+    status: str

--- a/backend/routers/cars.py
+++ b/backend/routers/cars.py
@@ -5,7 +5,7 @@ import json
 
 from backend.schemas.database import get_db
 from backend.schemas import Car, Store, Deal
-from backend.models import CarCreate
+from backend.models import CarCreate, CarStatusUpdate
 from backend.auth import get_current_seller
 
 router = APIRouter(tags=["cars"])
@@ -192,7 +192,7 @@ async def update_car(
 @router.patch("/{car_id}/status", response_model=Dict[str, Any])
 async def update_car_status(
     car_id: int,
-    status: str,
+    status_update: CarStatusUpdate,
     current_user = Depends(get_current_seller),
     db: Session = Depends(get_db)
 ):
@@ -203,6 +203,8 @@ async def update_car_status(
 
     if car.seller_id != current_user.id:
         raise HTTPException(status_code=403, detail="У вас нет прав на обновление этого автомобиля")
+
+    status = status_update.status
 
     valid_statuses = ["active", "inactive", "sold"]
     if status not in valid_statuses:


### PR DESCRIPTION
## Summary
- add CarStatusUpdate model
- expose CarStatusUpdate via `backend.models`
- use CarStatusUpdate in router so PATCH /cars/{id}/status accepts JSON body

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684005fbadd48329a6de7a4087087671