### PR TITLE
Fix Next params usage

### DIFF
--- a/frontend/src/app/cars/[id]/page.tsx
+++ b/frontend/src/app/cars/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, use } from 'react';
 import { getCarById, addCarToFavorites, removeFromFavorites } from '@/lib/api';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -36,7 +36,8 @@ interface Car {
   status?: 'active' | 'inactive' | 'sold';
 }
 
-export default function CarDetailsPage({ params }: { params: { id: string } }) {
+export default function CarDetailsPage({ params }: { params: Promise<{ id: string }> | { id: string } }) {
+  const { id } = use(params);
   const [car, setCar] = useState<Car | null>(null);
   const [loading, setLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -47,7 +48,7 @@ export default function CarDetailsPage({ params }: { params: { id: string } }) {
     const fetchCar = async () => {
       try {
         setLoading(true);
-        const carData = await getCarById(parseInt(params.id));
+        const carData = await getCarById(parseInt(id));
         setCar(carData);
       } catch (error) {
         console.error('Ошибка при загрузке данных автомобиля:', error);
@@ -64,7 +65,7 @@ export default function CarDetailsPage({ params }: { params: { id: string } }) {
     setUserRole(role);
 
     fetchCar();
-  }, [params.id, router]);
+  }, [id, router]);
 
   const toggleFavorite = async () => {
     if (!car) return;

--- a/frontend/src/app/dashboard/seller/cars/[id]/edit/page.tsx
+++ b/frontend/src/app/dashboard/seller/cars/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, use } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -80,11 +80,11 @@ const formSchema = z.object({
 type FormValues = z.infer<typeof formSchema>;
 
 interface EditCarPageProps {
-  params: { id: string };
+  params: Promise<{ id: string }> | { id: string }
 }
 
 export default function EditCarPage({ params }: EditCarPageProps) {
-  const carId = parseInt(params.id);
+  const carId = parseInt(use(params).id);
 
   const router = useRouter();
   const [error, setError] = useState('');
@@ -257,7 +257,7 @@ export default function EditCarPage({ params }: EditCarPageProps) {
   }
 
   return (
-    <div className="container max-w-4xl py-10">
+    <div className="container mx-auto max-w-4xl py-10">
       <div className="mb-8">
         <h1 className="text-3xl font-bold">Редактирование автомобиля</h1>
         <p className="text-muted-foreground mt-2">Внесите изменения в информацию об автомобиле</p>


### PR DESCRIPTION
## Summary
- unwrap Next.js `params` using React.use for dynamic car pages
- center edit car form container

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68406d7166d88329a15ab55b0a24e796