### PR TITLE
Improve dashboard UI

### DIFF
--- a/frontend/src/app/dashboard/buyer/page.tsx
+++ b/frontend/src/app/dashboard/buyer/page.tsx
@@ -4,6 +4,15 @@ import { useEffect, useState } from 'react';
 import { getUserProfile } from '@/lib/api';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 
 export default function BuyerDashboard() {
   const [user, setUser] = useState(null);
@@ -53,78 +62,129 @@ export default function BuyerDashboard() {
       <header className="bg-white shadow">
         <div className="max-w-7xl mx-auto px-4 py-6 sm:px-6 lg:px-8 flex justify-between items-center">
           <h1 className="text-3xl font-bold text-gray-900">Личный кабинет</h1>
-          <div className="flex gap-4">
-            <button
-              onClick={() => {
-                localStorage.removeItem('auth_token');
-                localStorage.removeItem('user_role');
-                router.push('/auth/login');
-              }}
-              className="text-sm text-gray-600 hover:text-gray-900 transition"
-            >
-              Выйти
-            </button>
-          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              localStorage.removeItem('auth_token');
+              localStorage.removeItem('user_role');
+              router.push('/auth/login');
+            }}
+          >
+            Выйти
+          </Button>
         </div>
       </header>
 
       {/* Основной контент */}
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         {/* Приветствие */}
-        <div className="bg-white shadow-sm rounded-lg p-6 mb-6">
-          <h2 className="text-2xl font-semibold mb-3">Добро пожаловать, {user?.name || 'Пользователь'}</h2>
-          <p className="text-gray-600">Выберите нужный раздел, чтобы начать работу с платформой.</p>
-        </div>
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle className="text-2xl">Добро пожаловать, {user?.name || 'Пользователь'}</CardTitle>
+            <CardDescription>
+              Выберите нужный раздел, чтобы начать работу с платформой.
+            </CardDescription>
+          </CardHeader>
+        </Card>
 
         {/* Карточки с разделами */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {/* Каталог автомобилей */}
           <Link href="/cars" className="block">
-            <div className="bg-white shadow-sm hover:shadow-md rounded-lg p-6 transition duration-200">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-xl font-medium">Каталог автомобилей</h3>
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-500">
+            <Card className="hover:shadow-md transition">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 mb-2">
+                <CardTitle className="text-xl">Каталог автомобилей</CardTitle>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-muted-foreground"
+                >
                   <rect x="2" y="4" width="20" height="16" rx="2" />
                   <path d="M8 21v-3a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v3" />
                 </svg>
-              </div>
-              <p className="text-gray-600">Просмотрите доступные автомобили и выберите подходящий для вас.</p>
-            </div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  Просмотрите доступные автомобили и выберите подходящий для вас.
+                </p>
+              </CardContent>
+            </Card>
           </Link>
 
           {/* Избранное */}
           <Link href="/favorites" className="block">
-            <div className="bg-white shadow-sm hover:shadow-md rounded-lg p-6 transition duration-200">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-xl font-medium">Избранное</h3>
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-500">
+            <Card className="hover:shadow-md transition">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 mb-2">
+                <CardTitle className="text-xl">Избранное</CardTitle>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-muted-foreground"
+                >
                   <path d="M20.42 4.58a5.4 5.4 0 0 0-7.65 0l-.77.78-.77-.78a5.4 5.4 0 0 0-7.65 0C1.46 6.7 1.33 10.28 4 13l8 8 8-8c2.67-2.72 2.54-6.3.42-8.42z" />
                 </svg>
-              </div>
-              <p className="text-gray-600">Сохраненные вами автомобили для последующего сравнения.</p>
-            </div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  Сохраненные вами автомобили для последующего сравнения.
+                </p>
+              </CardContent>
+            </Card>
           </Link>
 
           {/* Профиль */}
           <Link href="/dashboard/buyer/profile" className="block">
-            <div className="bg-white shadow-sm hover:shadow-md rounded-lg p-6 transition duration-200">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-xl font-medium">Профиль</h3>
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-500">
+            <Card className="hover:shadow-md transition">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 mb-2">
+                <CardTitle className="text-xl">Профиль</CardTitle>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-muted-foreground"
+                >
                   <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
                   <circle cx="12" cy="7" r="4" />
                 </svg>
-              </div>
-              <p className="text-gray-600">Управляйте вашими личными данными и настройками.</p>
-            </div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  Управляйте вашими личными данными и настройками.
+                </p>
+              </CardContent>
+            </Card>
           </Link>
         </div>
 
         {/* Раздел подсказок */}
-        <div className="bg-blue-50 border-l-4 border-blue-500 rounded-lg p-6 mt-8">
-          <h3 className="text-lg font-medium text-blue-800 mb-2">Полезная информация</h3>
-          <p className="text-blue-700">Перейдите в каталог автомобилей, чтобы начать поиск. Наиболее понравившиеся автомобили вы можете добавить в избранное.</p>
-        </div>
+        <Alert className="mt-8">
+          <AlertTitle>Полезная информация</AlertTitle>
+          <AlertDescription>
+            Перейдите в каталог автомобилей, чтобы начать поиск. Наиболее
+            понравившиеся автомобили вы можете добавить в избранное.
+          </AlertDescription>
+        </Alert>
       </main>
     </div>
   );

--- a/frontend/src/app/dashboard/seller/page.tsx
+++ b/frontend/src/app/dashboard/seller/page.tsx
@@ -7,6 +7,14 @@ import { useRouter } from 'next/navigation';
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -156,19 +164,20 @@ export default function SellerDashboard() {
         <div className="max-w-7xl mx-auto px-4 py-6 sm:px-6 lg:px-8 flex justify-between items-center">
           <h1 className="text-3xl font-bold text-gray-900">Панель продавца</h1>
           <div className="flex gap-4">
-            <Link href="/profile" className="text-sm text-gray-600 hover:text-gray-900 transition">
-              Профиль
-            </Link>
-            <button
+            <Button asChild variant="outline" size="sm">
+              <Link href="/profile">Профиль</Link>
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
               onClick={() => {
                 localStorage.removeItem('auth_token');
                 localStorage.removeItem('user_role');
                 router.push('/auth/login');
               }}
-              className="text-sm text-gray-600 hover:text-gray-900 transition"
             >
               Выйти
-            </button>
+            </Button>
           </div>
         </div>
       </header>
@@ -176,73 +185,125 @@ export default function SellerDashboard() {
       {/* Основной контент */}
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         {/* Приветствие */}
-        <div className="bg-white shadow-sm rounded-lg p-6 mb-6 border border-gray-200">
-          <h2 className="text-2xl font-semibold mb-3">Добрый день, {user?.name || 'Продавец'}</h2>
-          <p className="text-gray-600">Управляйте вашими автомобилями и следите за статистикой продаж.</p>
-        </div>
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle className="text-2xl">Добрый день, {user?.name || 'Продавец'}</CardTitle>
+            <CardDescription>
+              Управляйте вашими автомобилями и следите за статистикой продаж.
+            </CardDescription>
+          </CardHeader>
+        </Card>
 
         {/* Карточки с разделами */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
           {/* Мои автомобили */}
           <Link href="/dashboard/seller/cars" className="block">
-            <div className="bg-white shadow-sm hover:shadow-md rounded-lg p-6 transition duration-200 border border-gray-200">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-xl font-medium">Мои автомобили</h3>
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-500">
+            <Card className="hover:shadow-md transition">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 mb-2">
+                <CardTitle className="text-xl">Мои автомобили</CardTitle>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-muted-foreground"
+                >
                   <rect x="2" y="4" width="20" height="16" rx="2" />
                   <line x1="6" y1="12" x2="18" y2="12" />
                 </svg>
-              </div>
-              <p className="text-gray-600">Управляйте существующими объявлениями о продаже автомобилей.</p>
-            </div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  Управляйте существующими объявлениями о продаже автомобилей.
+                </p>
+              </CardContent>
+            </Card>
           </Link>
 
           {/* Добавить автомобиль */}
           <Link href="/dashboard/seller/cars/add" className="block">
-            <div className="bg-white shadow-sm hover:shadow-md rounded-lg p-6 transition duration-200 border border-gray-200">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-xl font-medium">Добавить автомобиль</h3>
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-500">
+            <Card className="hover:shadow-md transition">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 mb-2">
+                <CardTitle className="text-xl">Добавить автомобиль</CardTitle>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-muted-foreground"
+                >
                   <circle cx="12" cy="12" r="10" />
                   <line x1="12" y1="8" x2="12" y2="16" />
                   <line x1="8" y1="12" x2="16" y2="12" />
                 </svg>
-              </div>
-              <p className="text-gray-600">Создайте новое объявление о продаже автомобиля.</p>
-            </div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  Создайте новое объявление о продаже автомобиля.
+                </p>
+              </CardContent>
+            </Card>
           </Link>
 
           {/* Профиль */}
           <Link href="/profile" className="block">
-            <div className="bg-white shadow-sm hover:shadow-md rounded-lg p-6 transition duration-200 border border-gray-200">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-xl font-medium">Профиль</h3>
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-500">
+            <Card className="hover:shadow-md transition">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 mb-2">
+                <CardTitle className="text-xl">Профиль</CardTitle>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-muted-foreground"
+                >
                   <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
                   <circle cx="12" cy="7" r="4" />
                 </svg>
-              </div>
-              <p className="text-gray-600">Управляйте вашими личными данными и настройками.</p>
-            </div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  Управляйте вашими личными данными и настройками.
+                </p>
+              </CardContent>
+            </Card>
           </Link>
         </div>
 
         {/* Последние добавленные автомобили */}
-        <div className="bg-white shadow-sm rounded-lg p-6 mb-6 border border-gray-200">
-          <div className="flex justify-between items-center mb-4">
-            <h3 className="text-xl font-semibold">Ваши автомобили</h3>
-            <Link href="/dashboard/seller/cars" className="text-gray-600 hover:text-gray-900 text-sm">
-              Показать все
-            </Link>
-          </div>
+        <Card className="mb-6">
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle className="text-xl">Ваши автомобили</CardTitle>
+            <Button variant="link" asChild size="sm" className="px-0">
+              <Link href="/dashboard/seller/cars">Показать все</Link>
+            </Button>
+          </CardHeader>
 
           {cars.length === 0 ? (
-            <div className="text-center py-8">
-              <p className="text-gray-500 mb-4">У вас пока нет добавленных автомобилей</p>
-              <Link href="/dashboard/seller/cars/add" className="inline-block bg-gray-800 hover:bg-black text-white font-medium py-2 px-4 rounded-md transition">
-                Добавить первый автомобиль
-              </Link>
-            </div>
+            <Alert className="text-center py-8">
+              <AlertTitle className="mb-2">У вас пока нет добавленных автомобилей</AlertTitle>
+              <AlertDescription className="mb-4">
+                Добавьте свой первый автомобиль для продажи.
+              </AlertDescription>
+              <Button asChild>
+                <Link href="/dashboard/seller/cars/add">Добавить первый автомобиль</Link>
+              </Button>
+            </Alert>
           ) : (
             <div className="overflow-x-auto">
               <table className="min-w-full divide-y divide-gray-200">
@@ -326,7 +387,7 @@ export default function SellerDashboard() {
               </table>
             </div>
           )}
-        </div>
+        </Card>
       </main>
 
       {/* Модальное окно предпросмотра */}


### PR DESCRIPTION
## Summary
- integrate shadcn UI components in buyer and seller dashboards
- add cards for navigation blocks
- restyle greeting sections and alerts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68406ef68ff88329b80b80b2e280efa0