### PR TITLE
Localize condition labels

### DIFF
--- a/frontend/src/app/dashboard/seller/cars/page.tsx
+++ b/frontend/src/app/dashboard/seller/cars/page.tsx
@@ -151,6 +151,17 @@ export default function SellerCars() {
     }
   };
 
+  const getConditionLabel = (condition?: string) => {
+    switch (condition) {
+      case 'new':
+        return 'Новый';
+      case 'used':
+        return 'С пробегом';
+      default:
+        return condition || 'Не указано';
+    }
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -213,7 +224,7 @@ export default function SellerCars() {
                       <div className="text-sm text-muted-foreground">{car.year} г.</div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="text-sm">{car.transmission}, {car.condition}</div>
+                      <div className="text-sm">{car.transmission}, {getConditionLabel(car.condition)}</div>
                       <div className="text-sm text-muted-foreground">Пробег: {car.mileage} км</div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
@@ -316,7 +327,7 @@ export default function SellerCars() {
                   </div>
                   <div className="space-y-1">
                     <p className="text-sm text-muted-foreground">Состояние</p>
-                    <p>{selectedCar.condition}</p>
+                    <p>{getConditionLabel(selectedCar.condition)}</p>
                   </div>
                 </div>
               </div>

--- a/frontend/src/app/dashboard/seller/page.tsx
+++ b/frontend/src/app/dashboard/seller/page.tsx
@@ -149,6 +149,17 @@ export default function SellerDashboard() {
     }
   };
 
+  const getConditionLabel = (condition?: string) => {
+    switch (condition) {
+      case 'new':
+        return 'Новый';
+      case 'used':
+        return 'С пробегом';
+      default:
+        return condition || 'Не указано';
+    }
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -419,7 +430,7 @@ export default function SellerDashboard() {
                   </div>
                   <div className="space-y-1">
                     <p className="text-sm text-muted-foreground">Состояние</p>
-                    <p>{selectedCar.condition}</p>
+                    <p>{getConditionLabel(selectedCar.condition)}</p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- show Russian labels for car condition in seller dashboard pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684070d9e6388329a1eb8105b61c7943