### PR TITLE
Add car details modal and improve homepage

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { getAllCars } from "@/lib/api";
+import { getAllCars, getCarById } from "@/lib/api";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,6 +10,8 @@ import { Slider } from "@/components/ui/slider";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import CarDetailsModal from "@/components/CarDetailsModal";
+import { Car as CarIcon, ShieldCheck, Phone } from "lucide-react";
 
 // Типы данных для автомобилей
 interface Car {
@@ -47,6 +49,9 @@ export default function Home() {
   const [searchTerm, setSearchTerm] = useState("");
   const [filters, setFilters] = useState<Filters>({});
   const [showFilters, setShowFilters] = useState(false);
+  const [selectedCar, setSelectedCar] = useState<Car | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalLoading, setModalLoading] = useState(false);
 
   // Загрузка списка автомобилей
   useEffect(() => {
@@ -102,6 +107,19 @@ export default function Home() {
     setSearchTerm("");
   };
 
+  const openCarDetails = async (carId: number) => {
+    try {
+      setModalLoading(true);
+      setIsModalOpen(true);
+      const carDetails = await getCarById(carId);
+      setSelectedCar(carDetails);
+    } catch (error) {
+      console.error("Ошибка при загрузке данных автомобиля:", error);
+    } finally {
+      setModalLoading(false);
+    }
+  };
+
   return (
     <main className="min-h-screen bg-background">
       {/* Hero секция с информацией о компании */}
@@ -121,6 +139,27 @@ export default function Home() {
             <Link href="/auth/register/seller">
               <Button variant="outline" size="lg">Продать автомобиль</Button>
             </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Наши преимущества */}
+      <section className="py-12 px-6 bg-secondary/50">
+        <div className="container max-w-6xl mx-auto grid md:grid-cols-3 gap-8 text-center">
+          <div className="flex flex-col items-center gap-2">
+            <CarIcon className="h-8 w-8 text-primary" />
+            <h3 className="text-xl font-semibold">Большой выбор</h3>
+            <p className="text-muted-foreground">Сотни моделей от проверенных продавцов</p>
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <ShieldCheck className="h-8 w-8 text-primary" />
+            <h3 className="text-xl font-semibold">Прозрачные цены</h3>
+            <p className="text-muted-foreground">Все автомобили проходят тщательную проверку</p>
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <Phone className="h-8 w-8 text-primary" />
+            <h3 className="text-xl font-semibold">Поддержка 24/7</h3>
+            <p className="text-muted-foreground">Мы всегда готовы помочь вам с выбором</p>
           </div>
         </div>
       </section>
@@ -329,7 +368,7 @@ export default function Home() {
                         </div>
                       )}
                     </div>
-                    <Button className="w-full mt-4">Подробнее</Button>
+                    <Button className="w-full mt-4" onClick={() => openCarDetails(car.id)}>Подробнее</Button>
                   </div>
                 </Card>
               ))}
@@ -342,6 +381,12 @@ export default function Home() {
           )}
         </div>
       </section>
+      <CarDetailsModal
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        car={selectedCar}
+        loading={modalLoading}
+      />
     </main>
   );
 }

--- a/frontend/src/components/CarDetailsModal.tsx
+++ b/frontend/src/components/CarDetailsModal.tsx
@@ -1,0 +1,132 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface CarDetails {
+  id: number;
+  brand: string;
+  model: string;
+  year: number;
+  power?: number;
+  transmission: string;
+  condition: string;
+  mileage: number;
+  features?: string[];
+  price: number;
+  seller?: {
+    name: string;
+    contact_info?: string;
+  };
+  store?: {
+    name: string;
+    address?: string;
+  };
+}
+
+interface CarDetailsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  car: CarDetails | null;
+  loading: boolean;
+}
+
+export default function CarDetailsModal({ open, onOpenChange, car, loading }: CarDetailsModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        {loading ? (
+          <div className="h-48 flex items-center justify-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-gray-900" />
+          </div>
+        ) : car ? (
+          <>
+            <DialogHeader>
+              <DialogTitle className="text-2xl">
+                {car.brand} {car.model}, {car.year}
+              </DialogTitle>
+              <DialogDescription>
+                <span className="text-xl font-bold">{car.price.toLocaleString()} ₽</span>
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-4">
+              <div>
+                <div className="aspect-video bg-gray-200 rounded-md overflow-hidden">
+                  <div className="w-full h-full flex items-center justify-center text-gray-500">Фото отсутствует</div>
+                </div>
+              </div>
+
+              <div>
+                <h3 className="font-semibold text-lg mb-2">Характеристики</h3>
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <p className="text-sm text-gray-500">Год выпуска</p>
+                    <p className="font-medium">{car.year}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-gray-500">Пробег</p>
+                    <p className="font-medium">{car.mileage.toLocaleString()} км</p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-gray-500">КПП</p>
+                    <p className="font-medium">{car.transmission}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm text-gray-500">Состояние</p>
+                    <p className="font-medium">{car.condition === "new" ? "Новый" : "С пробегом"}</p>
+                  </div>
+                  {car.power && (
+                    <div>
+                      <p className="text-sm text-gray-500">Мощность</p>
+                      <p className="font-medium">{car.power} л.с.</p>
+                    </div>
+                  )}
+                </div>
+
+                {car.features && car.features.length > 0 && (
+                  <div className="mt-4">
+                    <h3 className="font-semibold text-lg mb-2">Особенности</h3>
+                    <ul className="list-disc list-inside space-y-1">
+                      {car.features.map((feature, index) => (
+                        <li key={index} className="text-sm">
+                          {feature}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {car.seller && (
+                  <div className="mt-4">
+                    <h3 className="font-semibold text-lg mb-2">Продавец</h3>
+                    <p className="text-sm">
+                      {car.seller.name}
+                      {car.seller.contact_info ? `, ${car.seller.contact_info}` : ""}
+                    </p>
+                  </div>
+                )}
+
+                {car.store && (
+                  <div className="mt-4">
+                    <h3 className="font-semibold text-lg mb-2">Магазин</h3>
+                    <p className="text-sm">
+                      {car.store.name}
+                      {car.store.address ? `, ${car.store.address}` : ""}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <DialogFooter className="flex flex-col sm:flex-row gap-2 mt-6">
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Закрыть
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <div className="p-4 text-center text-gray-500">Не удалось загрузить информацию об автомобиле</div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- show car details with a modal on main page
- add features section on homepage
- create reusable `CarDetailsModal` component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p frontend/tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6840987bfa1883299cb4eb502dba7bd7