### PR TITLE
Fix animejs import path

### DIFF
--- a/frontend/src/components/AIAssistant.tsx
+++ b/frontend/src/components/AIAssistant.tsx
@@ -7,7 +7,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { MessageCircle, Send, X, Bot } from "lucide-react";
 // @ts-ignore
-import anime from 'animejs/lib/anime.es.js';
+import anime from 'animejs';
 
 interface Message {
   role: "user" | "assistant";


### PR DESCRIPTION
## Summary
- fix incorrect animejs import path in AIAssistant component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6842a77158348329a5ce36e79fca7db6